### PR TITLE
Fixed reference to the wrong example picture

### DIFF
--- a/draft-ietf-wish-whep.md
+++ b/draft-ietf-wish-whep.md
@@ -375,7 +375,7 @@ a=end-of-candidates
 ~~~~~
 {: title="Example of an ICE restart request and response" #trickle-restart-example}
 
-{{trickle-ice-example}} demonstrates a Trickle ICE restart procedure example. The WHEP player sends a PATCH request containing updated ICE information, including a new ufrag and password, along with newly gathered ICE candidates. In response, the WHEP session provides ICE information for the session after the ICE restart, including the updated ufrag and password, as well as the previous ICE candidate.
+{{trickle-restart-example}} demonstrates a Trickle ICE restart procedure example. The WHEP player sends a PATCH request containing updated ICE information, including a new ufrag and password, along with newly gathered ICE candidates. In response, the WHEP session provides ICE information for the session after the ICE restart, including the updated ufrag and password, as well as the previous ICE candidate.
 
 ## WebRTC constraints
 


### PR DESCRIPTION
In section 4.4.3 the text below the example "picture" references the picture from the previous section 4.4.2. This PR changes it to the correct reference.